### PR TITLE
Added do_action to catch the template name

### DIFF
--- a/inc/blade/application/models/main-model.php
+++ b/inc/blade/application/models/main-model.php
@@ -31,6 +31,10 @@ class WP_Blade_Main_Model {
 	 */
 	public function template_include_blade( $template ) {
 
+		# Able to catch the real template name, not the cached view.
+		do_action('template_include_blade', $template);
+
+
 		if( $this->bladedTemplate )
 			return $this->bladedTemplate;
 		if( ! $template )


### PR DESCRIPTION
Nice small feature to catch a real template name. The "template_include" action only returns the name of the hashed cache view.